### PR TITLE
Break-word and fixed width of columns with horizontal scroll

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -717,7 +717,7 @@ Contains a v-data-table component, which is responsible for rendering the table.
 
 ### Props
 
-- `headers (Array, required)`: Specifies the headers of the table, including text, value, and optional configuration.
+- `headers (Array, required)`: Specifies the headers of the table, including title, value, and optional configuration.
 - `items (Array, required)`: Specifies the data items to be displayed in the table.
 - `options (Object)`: Additional options to configure the behavior and appearance of the table.
 - `showHeaders (Boolean, default: true)`: Indicates whether to display the table headers.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "resize-observer": "^1.0.4",
     "vite-plugin-vuetify": "^2.0.3",
     "vue": "^3.4.21",
-    "vue3-apexcharts": "^1.5.3",
+    "vue3-apexcharts": "^1.8.0",
     "vuetify": "^3.5.9",
     "webfontloader": "^1.6.28"
   },

--- a/src/components/MDataTable/MDataTable.css
+++ b/src/components/MDataTable/MDataTable.css
@@ -1,18 +1,18 @@
 ::v-deep .v-data-table__th {
-  border-right: 1px solid #0000001e !important; /* Change color as needed */
+  border-right: 1px solid #0000001e !important;
   background-color: #f9f9f9 !important;
 }
 
 ::v-deep .v-data-table__th .v-data-table-header__content span {
   white-space: normal !important;
   word-wrap: break-word !important;
-  word-break: break-all !important;
+  word-break: normal !important;
 }
 
 ::v-deep .v-data-table__td {
   white-space: normal !important;
   word-wrap: break-word !important;
-  word-break: break-all !important;
+  word-break: normal !important;
 }
 
 /* Remove border from the last header cell */

--- a/src/components/MDataTable/MDataTable.vue
+++ b/src/components/MDataTable/MDataTable.vue
@@ -69,7 +69,7 @@
           <v-col cols="auto">
             <v-icon style="font-size: 0.85rem" class="mr-1">mdi-plus</v-icon>
           </v-col>
-          <v-col cols="auto"> {{ $t('inputOutputData.addItem') }} </v-col>
+          <v-col cols="auto">Add Item</v-col>
         </v-row>
       </v-btn>
     </template>


### PR DESCRIPTION
Break-word for title headers and fixed width of columns with horizontal scroll.
Fixes this issue: https://github.com/baobabsoluciones/mango-ui/issues/59 