### PR TITLE
Apex chart bugfix for height and width

### DIFF
--- a/src/components/KPICharts/charts/AreaChart.vue
+++ b/src/components/KPICharts/charts/AreaChart.vue
@@ -29,7 +29,7 @@ import VueApexCharts from "vue3-apexcharts";
             },
             height: {
                 type: String,
-                default: '100px'
+                default: '150px'
             }
         },
         computed: {

--- a/src/components/KPICharts/charts/AreaChart.vue
+++ b/src/components/KPICharts/charts/AreaChart.vue
@@ -1,6 +1,6 @@
 <template>
     <div class= "area-chart" :style="{ width: width, height: height }">
-        <apexchart :options="chartOptions" :series="chartSeries"></apexchart>
+        <apexchart :options="chartOptions" :series="chartSeries" :width="width" :height="height"></apexchart>
     </div>
 </template>
 
@@ -29,21 +29,17 @@ import VueApexCharts from "vue3-apexcharts";
             },
             height: {
                 type: String,
-                default: '150px'
+                default: '100px'
             }
         },
         computed: {
             chartSeries() {
                 return [{data: this.series}]
-            }
-        },
-        data () {
-            return {
-                chartOptions: {
+            },
+            chartOptions() {
+                return {
                     chart: {
                         type: 'area',
-                        height: this.height,
-                        width: this.width,
                         toolbar: {
                             show: false
                         },
@@ -102,9 +98,12 @@ import VueApexCharts from "vue3-apexcharts";
                         },
                     },
                     colors: [this.chartColor],
-                },
+                }
             }
-        },  
+        },
+        data() {
+            return {}
+        },
     }
 </script>
 

--- a/src/components/KPICharts/charts/DonutChart.vue
+++ b/src/components/KPICharts/charts/DonutChart.vue
@@ -35,8 +35,6 @@ import VueApexCharts from "vue3-apexcharts";
                 chartOptions: {
                     chart: {
                         type: 'radialBar',
-                        height: this.height,
-                        width: this.width,
                     },
                     stroke: {
                         lineCap: 'round'

--- a/src/components/KPICharts/charts/DonutChart.vue
+++ b/src/components/KPICharts/charts/DonutChart.vue
@@ -1,6 +1,6 @@
 <template>
     <div class= "donut-chart" :style="{ width: width, height: height }">
-        <apexchart :options="chartOptions" :series="series"></apexchart>
+        <apexchart :options="chartOptions" :series="series" :width="width" :height="height"></apexchart>
     </div>
 </template>
 


### PR DESCRIPTION
Height and width options were passed by chart options and it should be directly passed as a prop