### PR TITLE
Updated css styles for pagination

### DIFF
--- a/src/components/MDataTable/MDataTable.css
+++ b/src/components/MDataTable/MDataTable.css
@@ -97,6 +97,21 @@
 
 ::v-deep .v-data-table-footer {
   justify-content: space-between !important;
+  position: sticky !important;
+  left: 0 !important;
+  right: 0 !important;
+  background-color: white !important;
+  z-index: 1 !important;
+  width: 100% !important;
+  max-width: 100vw !important;
+  margin: 0 auto !important;
+}
+
+::v-deep .v-data-table-footer .v-pagination {
+  margin: 0 auto !important;
+  position: relative !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
 }
 
 .hide-footer ::v-deep .v-data-table-footer {


### PR DESCRIPTION
Fixed an issue where tables with many columns would expand unnecessarily wide due to pagination centering. The pagination now stays centered relative to the viewport width instead of the total table width, improving the user experience and preventing layout issues.

The fix includes proper sticky positioning of the footer and viewport-relative width constraints to ensure consistent pagination positioning regardless of table width.